### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(name='ranking_table_tennis',
       url='http://github.com/srvanrell/ranking-table-tennis',
       author='Sebastian Vanrell',
       author_email='srvanrell@gmail.com',
-      license='MIT',
       packages=['ranking_table_tennis'],
       scripts=['bin/rtt'],
       include_package_data=True,
@@ -57,5 +56,8 @@ setup(name='ranking_table_tennis',
         'develop': PostDevelopCommand,
         'install': PostInstallCommand,
       },
+      classifiers=[
+          'License :: OSI Approved :: MIT License'
+      ],
       zip_safe=False)
 


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.