### PR TITLE
Move prints to logging when possible

### DIFF
--- a/ranking_table_tennis/command_line.py
+++ b/ranking_table_tennis/command_line.py
@@ -54,7 +54,7 @@ def main():
     numeric_log_level = getattr(logging, args.log.upper())
     logger.setLevel(numeric_log_level)
 
-    logger.debug(f"Working directory: {os.path.abspath(os.path.curdir)}")
+    logger.debug(f"Working directory: '{os.path.abspath(os.path.curdir)}'")
 
     # FIXME calls are not performed in the best way.
     if args.cmd == "preprocess":

--- a/ranking_table_tennis/command_line.py
+++ b/ranking_table_tennis/command_line.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 import textwrap
 
@@ -21,6 +22,12 @@ def main():
         choices=["preprocess", "compute", "publish"],
     )
     parser.add_argument(
+        "--log",
+        help="Define the level of logging from string.",
+        choices=["debug", "info", "warning", "error", "critical"],
+        default="info",
+    )
+    parser.add_argument(
         "--offline",
         help="Execute the given command locally. Compute is always offline.",
         action="store_true",
@@ -39,7 +46,13 @@ def main():
     )
     args = parser.parse_args()
 
-    print(f"Working directory: {os.path.abspath(os.path.curdir)}")
+    # assuming loglevel is bound to the string value obtained from the
+    # command line argument. Convert to upper case to allow the user to
+    # specify --log=DEBUG or --log=debug
+    numeric_log_level = getattr(logging, args.log.upper())
+    logging.basicConfig(level=numeric_log_level)
+    logger = logging.getLogger(__name__)
+    logger.info(f"Working directory: {os.path.abspath(os.path.curdir)}")
 
     # FIXME calls are not performed in the best way.
     if args.cmd == "preprocess":
@@ -55,7 +68,7 @@ def main():
 
         publish.main(args.offline, args.last, args.tournament_num)
     else:
-        print("you shouldn't see this message")
+        logger.error("you shouldn't see this message")
 
 
 if __name__ == "__main__":

--- a/ranking_table_tennis/command_line.py
+++ b/ranking_table_tennis/command_line.py
@@ -54,7 +54,7 @@ def main():
     numeric_log_level = getattr(logging, args.log.upper())
     logger.setLevel(numeric_log_level)
 
-    logger.debug(f"Working directory: '{os.path.abspath(os.path.curdir)}'")
+    logger.debug("~ Working directory: '%s'", os.path.abspath(os.path.curdir))
 
     # FIXME calls are not performed in the best way.
     if args.cmd == "preprocess":

--- a/ranking_table_tennis/command_line.py
+++ b/ranking_table_tennis/command_line.py
@@ -3,6 +3,8 @@ import logging
 import os
 import textwrap
 
+from ranking_table_tennis.helpers.logging import logger
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -50,9 +52,9 @@ def main():
     # command line argument. Convert to upper case to allow the user to
     # specify --log=DEBUG or --log=debug
     numeric_log_level = getattr(logging, args.log.upper())
-    logging.basicConfig(level=numeric_log_level)
-    logger = logging.getLogger(__name__)
-    logger.info(f"Working directory: {os.path.abspath(os.path.curdir)}")
+    logger.setLevel(numeric_log_level)
+
+    logger.debug(f"Working directory: {os.path.abspath(os.path.curdir)}")
 
     # FIXME calls are not performed in the best way.
     if args.cmd == "preprocess":

--- a/ranking_table_tennis/compute_rankings.py
+++ b/ranking_table_tennis/compute_rankings.py
@@ -1,3 +1,5 @@
+import logging
+
 from ranking_table_tennis import helpers
 from ranking_table_tennis.configs import ConfigManager
 
@@ -10,7 +12,7 @@ def main():
     It will read players, tournaments in pickles.
     It will save players, tournaments and rankings in pickles.
     """
-    print("\n## Starting to compute rankings\n")
+    logging.info("\n## Starting to compute rankings\n")
 
     ConfigManager().set_current_config(date="220101")
     cfg = ConfigManager().current_config
@@ -30,7 +32,7 @@ def main():
     tids = [initial_tid] + [tid for tid in tournaments]
 
     for tid in tournaments:
-        print("==", tid, "==")
+        logging.info("==", tid, "==")
 
         # Get the tid of the previous tournament
         prev_tid = tids[tids.index(tid) - 1]

--- a/ranking_table_tennis/compute_rankings.py
+++ b/ranking_table_tennis/compute_rankings.py
@@ -14,7 +14,7 @@ def main():
     It will read players, tournaments in pickles.
     It will save players, tournaments and rankings in pickles.
     """
-    logger.info("## Starting to compute rankings")
+    logger.info("Starting to compute rankings!")
 
     ConfigManager().set_current_config(date="220101")
     cfg = ConfigManager().current_config
@@ -34,7 +34,7 @@ def main():
     tids = [initial_tid] + [tid for tid in tournaments]
 
     for tid in tournaments:
-        logger.info("== %s ==", tid)
+        logger.info("** Computing %s", tid)
 
         # Get the tid of the previous tournament
         prev_tid = tids[tids.index(tid) - 1]

--- a/ranking_table_tennis/compute_rankings.py
+++ b/ranking_table_tennis/compute_rankings.py
@@ -3,6 +3,8 @@ import logging
 from ranking_table_tennis import helpers
 from ranking_table_tennis.configs import ConfigManager
 
+logger = logging.getLogger(__name__)
+
 
 def main():
     """Compute rating and championship points of loaded tournaments.
@@ -12,7 +14,7 @@ def main():
     It will read players, tournaments in pickles.
     It will save players, tournaments and rankings in pickles.
     """
-    logging.info("\n## Starting to compute rankings\n")
+    logger.info("## Starting to compute rankings")
 
     ConfigManager().set_current_config(date="220101")
     cfg = ConfigManager().current_config
@@ -32,7 +34,7 @@ def main():
     tids = [initial_tid] + [tid for tid in tournaments]
 
     for tid in tournaments:
-        logging.info("==", tid, "==")
+        logger.info("== %s ==", tid)
 
         # Get the tid of the previous tournament
         prev_tid = tids[tids.index(tid) - 1]

--- a/ranking_table_tennis/config/logging.yaml
+++ b/ranking_table_tennis/config/logging.yaml
@@ -1,7 +1,7 @@
 version: 1
 formatters:
   simple:
-    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    format: '[%(relativeCreated)d ms] %(message)-100s [%(levelname)s:%(module)s.%(funcName)s:%(lineno)d]'
 handlers:
   console:
     class: logging.StreamHandler

--- a/ranking_table_tennis/config/logging.yaml
+++ b/ranking_table_tennis/config/logging.yaml
@@ -1,0 +1,18 @@
+version: 1
+formatters:
+  simple:
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: DEBUG
+    formatter: simple
+    stream: ext://sys.stdout
+loggers:
+  ranking_table_tennis:
+    level: INFO
+    handlers: [console]
+    propagate: no
+root:
+  level: DEBUG
+  handlers: [console]

--- a/ranking_table_tennis/configs.py
+++ b/ranking_table_tennis/configs.py
@@ -1,4 +1,5 @@
 import glob
+import logging
 import os
 
 import hydra
@@ -7,6 +8,8 @@ from omegaconf import OmegaConf
 
 USER_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config")
 AVAILABLE_CONFIGS = glob.glob(os.path.join(USER_CONFIG_PATH, "config_*_*.yaml"))
+
+logger = logging.getLogger(__name__)
 
 
 class ConfigManager:
@@ -22,10 +25,10 @@ class ConfigManager:
 
     def set_available_configs(self):
         ConfigManager._available_configs = []
-        print("\n## Available configs\n")
+        logger.debug("\n## Available configs\n")
         for path in sorted(AVAILABLE_CONFIGS, reverse=True):
             ConfigManager._available_configs.append(Configuration(path))
-            print(ConfigManager._available_configs[-1])
+            logger.debug(ConfigManager._available_configs[-1])
 
     def get_valid_config(self, date):
         self.initialize()
@@ -65,8 +68,8 @@ class Configuration:
     def get_config(self):
         """Load config from the config_path."""
         if self.dict_cfg is None:
-            print("\n## Loading config\n")
-            print(f"Config directory: {os.path.abspath(self._config_path)}\n")
+            logger.debug("\n## Loading config\n")
+            logger.debug(f"Config directory: {os.path.abspath(self._config_path)}\n")
 
             base_cfg = self._load_base_config()
             tables_cfg = self._load_tables_config()

--- a/ranking_table_tennis/configs.py
+++ b/ranking_table_tennis/configs.py
@@ -27,7 +27,7 @@ class ConfigManager:
         ConfigManager._available_configs = []
         for path in sorted(AVAILABLE_CONFIGS, reverse=True):
             ConfigManager._available_configs.append(Configuration(path))
-            logger.debug("Available config: %s", ConfigManager._available_configs[-1])
+            logger.debug("~ Available %s", ConfigManager._available_configs[-1])
 
     def get_valid_config(self, date):
         self.initialize()
@@ -67,7 +67,7 @@ class Configuration:
     def get_config(self):
         """Load config from the config_path."""
         if self.dict_cfg is None:
-            logger.debug("Config directory: %s", os.path.abspath(self._config_path))
+            logger.debug("~ Config directory: '%s'", os.path.abspath(self._config_path))
 
             base_cfg = self._load_base_config()
             tables_cfg = self._load_tables_config()
@@ -80,7 +80,7 @@ class Configuration:
         with hydra.initialize_config_dir(
             version_base=None, config_dir=config_dir, job_name="rtt_app"
         ):
-            logger.debug("Loading config: %s", self._config_name)
+            logger.debug("~ Loading '%s'", self._config_name)
             return hydra.compose(config_name=self._config_name)
 
     def _load_tables_config(self):

--- a/ranking_table_tennis/configs.py
+++ b/ranking_table_tennis/configs.py
@@ -25,10 +25,9 @@ class ConfigManager:
 
     def set_available_configs(self):
         ConfigManager._available_configs = []
-        logger.debug("\n## Available configs\n")
         for path in sorted(AVAILABLE_CONFIGS, reverse=True):
             ConfigManager._available_configs.append(Configuration(path))
-            logger.debug(ConfigManager._available_configs[-1])
+            logger.debug("Available config: %s", ConfigManager._available_configs[-1])
 
     def get_valid_config(self, date):
         self.initialize()
@@ -68,8 +67,7 @@ class Configuration:
     def get_config(self):
         """Load config from the config_path."""
         if self.dict_cfg is None:
-            logger.debug("\n## Loading config\n")
-            logger.debug(f"Config directory: {os.path.abspath(self._config_path)}\n")
+            logger.debug("Config directory: %s", os.path.abspath(self._config_path))
 
             base_cfg = self._load_base_config()
             tables_cfg = self._load_tables_config()
@@ -82,6 +80,7 @@ class Configuration:
         with hydra.initialize_config_dir(
             version_base=None, config_dir=config_dir, job_name="rtt_app"
         ):
+            logger.debug("Loading config: %s", self._config_name)
             return hydra.compose(config_name=self._config_name)
 
     def _load_tables_config(self):

--- a/ranking_table_tennis/helpers/excel.py
+++ b/ranking_table_tennis/helpers/excel.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import List
 
@@ -6,6 +7,8 @@ import pandas as pd
 from ranking_table_tennis import models
 from ranking_table_tennis.configs import ConfigManager
 from ranking_table_tennis.helpers.gspread import upload_sheet_from_df
+
+logger = logging.getLogger(__name__)
 
 
 def get_tournament_sheet_names_ordered() -> List[str]:
@@ -22,7 +25,7 @@ def load_players_sheet() -> models.Players:
     cfg = ConfigManager().current_config
     tournaments_xlsx = cfg.io.data_folder + cfg.io.xlsx.tournaments_filename
     players_df = pd.read_excel(tournaments_xlsx, sheet_name=cfg.sheetname.players, header=0)
-    print("> Reading", cfg.sheetname.players, "from", tournaments_xlsx, sep="\t")
+    logger.info("> Reading%s\tfrom\t%s", cfg.sheetname.players, tournaments_xlsx)
 
     players_df.rename(
         columns={
@@ -45,7 +48,7 @@ def load_initial_ranking_sheet() -> models.Rankings:
     initial_ranking_df = pd.read_excel(
         tournaments_xlsx, sheet_name=cfg.sheetname.initial_ranking, header=0
     )
-    print("> Reading", cfg.sheetname.initial_ranking, "from", tournaments_xlsx, sep="\t")
+    logger.info("> Reading%s\tfrom\t%s", cfg.sheetname.initial_ranking, tournaments_xlsx)
 
     columns_translations = {
         cfg.labels.tid: "tid",
@@ -77,7 +80,7 @@ def load_tournaments_sheets() -> models.Tournaments:
 
     to_concat = []
     for sheet_name in sheet_names:
-        print("> Reading", sheet_name, "from", tournaments_xlsx, sep="\t")
+        logger.info("> Reading%s\tfrom\t%s", sheet_name, tournaments_xlsx)
         raw_tournament = raw_tournaments[sheet_name]
 
         tournament_df = raw_tournament.iloc[5:].copy()
@@ -198,7 +201,7 @@ def save_raw_ranking(rankings: models.Rankings, players: models.Players, tid: st
     """Add players name to raw ranking to be save into a spreadsheet."""
     cfg = ConfigManager().current_config
     xlsx_filename = cfg.io.data_folder + f"raw_ranking_{tid}.xlsx"
-    print("<<<Saving raw ranking in", xlsx_filename, sep="\t")
+    logger.info("<<<Saving raw ranking in\t%s", xlsx_filename)
 
     # Rankings sorted by rating
     this_ranking_df = rankings[tid].sort_values("rating", ascending=False)
@@ -210,7 +213,7 @@ def save_raw_ranking(rankings: models.Rankings, players: models.Players, tid: st
 
 def _get_writer(xlsx_filename: str, sheet_name: str) -> pd.ExcelWriter:
     writer_mode = _get_writer_mode(xlsx_filename)
-    print("<<<Saving", sheet_name, "in", xlsx_filename, sep="\t")
+    logger.info("<<<Saving%s\tin\t%s", sheet_name, xlsx_filename)
     if writer_mode == "a":
         writer = pd.ExcelWriter(
             xlsx_filename, engine="openpyxl", mode=writer_mode, if_sheet_exists="replace"

--- a/ranking_table_tennis/helpers/excel.py
+++ b/ranking_table_tennis/helpers/excel.py
@@ -25,7 +25,7 @@ def load_players_sheet() -> models.Players:
     cfg = ConfigManager().current_config
     tournaments_xlsx = cfg.io.data_folder + cfg.io.xlsx.tournaments_filename
     players_df = pd.read_excel(tournaments_xlsx, sheet_name=cfg.sheetname.players, header=0)
-    logger.info("> Reading%s\tfrom\t%s", cfg.sheetname.players, tournaments_xlsx)
+    logger.info("> Reading '%s' @ '%s'", cfg.sheetname.players, cfg.io.xlsx.tournaments_filename)
 
     players_df.rename(
         columns={
@@ -48,7 +48,9 @@ def load_initial_ranking_sheet() -> models.Rankings:
     initial_ranking_df = pd.read_excel(
         tournaments_xlsx, sheet_name=cfg.sheetname.initial_ranking, header=0
     )
-    logger.info("> Reading%s\tfrom\t%s", cfg.sheetname.initial_ranking, tournaments_xlsx)
+    logger.info(
+        "> Reading '%s' @ '%s'", cfg.sheetname.initial_ranking, cfg.io.xlsx.tournaments_filename
+    )
 
     columns_translations = {
         cfg.labels.tid: "tid",
@@ -80,7 +82,7 @@ def load_tournaments_sheets() -> models.Tournaments:
 
     to_concat = []
     for sheet_name in sheet_names:
-        logger.info("> Reading%s\tfrom\t%s", sheet_name, tournaments_xlsx)
+        logger.info("> Reading '%s' @ '%s'", sheet_name, cfg.io.xlsx.tournaments_filename)
         raw_tournament = raw_tournaments[sheet_name]
 
         tournament_df = raw_tournament.iloc[5:].copy()
@@ -201,7 +203,7 @@ def save_raw_ranking(rankings: models.Rankings, players: models.Players, tid: st
     """Add players name to raw ranking to be save into a spreadsheet."""
     cfg = ConfigManager().current_config
     xlsx_filename = cfg.io.data_folder + f"raw_ranking_{tid}.xlsx"
-    logger.info("<<<Saving raw ranking in\t%s", xlsx_filename)
+    logger.info("< Saving raw ranking @ '%s'", xlsx_filename)
 
     # Rankings sorted by rating
     this_ranking_df = rankings[tid].sort_values("rating", ascending=False)
@@ -213,7 +215,7 @@ def save_raw_ranking(rankings: models.Rankings, players: models.Players, tid: st
 
 def _get_writer(xlsx_filename: str, sheet_name: str) -> pd.ExcelWriter:
     writer_mode = _get_writer_mode(xlsx_filename)
-    logger.info("<<<Saving%s\tin\t%s", sheet_name, xlsx_filename)
+    logger.info("< Saving '%s' @ '%s'", sheet_name, xlsx_filename)
     if writer_mode == "a":
         writer = pd.ExcelWriter(
             xlsx_filename, engine="openpyxl", mode=writer_mode, if_sheet_exists="replace"

--- a/ranking_table_tennis/helpers/excel.py
+++ b/ranking_table_tennis/helpers/excel.py
@@ -25,7 +25,7 @@ def load_players_sheet() -> models.Players:
     cfg = ConfigManager().current_config
     tournaments_xlsx = cfg.io.data_folder + cfg.io.xlsx.tournaments_filename
     players_df = pd.read_excel(tournaments_xlsx, sheet_name=cfg.sheetname.players, header=0)
-    logger.info("> Reading '%s' @ '%s'", cfg.sheetname.players, cfg.io.xlsx.tournaments_filename)
+    logger.debug("> Reading '%s' @ '%s'", cfg.sheetname.players, cfg.io.xlsx.tournaments_filename)
 
     players_df.rename(
         columns={
@@ -48,7 +48,7 @@ def load_initial_ranking_sheet() -> models.Rankings:
     initial_ranking_df = pd.read_excel(
         tournaments_xlsx, sheet_name=cfg.sheetname.initial_ranking, header=0
     )
-    logger.info(
+    logger.debug(
         "> Reading '%s' @ '%s'", cfg.sheetname.initial_ranking, cfg.io.xlsx.tournaments_filename
     )
 
@@ -82,7 +82,7 @@ def load_tournaments_sheets() -> models.Tournaments:
 
     to_concat = []
     for sheet_name in sheet_names:
-        logger.info("> Reading '%s' @ '%s'", sheet_name, cfg.io.xlsx.tournaments_filename)
+        logger.debug("> Reading '%s' @ '%s'", sheet_name, cfg.io.xlsx.tournaments_filename)
         raw_tournament = raw_tournaments[sheet_name]
 
         tournament_df = raw_tournament.iloc[5:].copy()
@@ -203,7 +203,7 @@ def save_raw_ranking(rankings: models.Rankings, players: models.Players, tid: st
     """Add players name to raw ranking to be save into a spreadsheet."""
     cfg = ConfigManager().current_config
     xlsx_filename = cfg.io.data_folder + f"raw_ranking_{tid}.xlsx"
-    logger.info("< Saving raw ranking @ '%s'", xlsx_filename)
+    logger.debug("< Saving raw ranking @ '%s'", xlsx_filename)
 
     # Rankings sorted by rating
     this_ranking_df = rankings[tid].sort_values("rating", ascending=False)
@@ -215,7 +215,7 @@ def save_raw_ranking(rankings: models.Rankings, players: models.Players, tid: st
 
 def _get_writer(xlsx_filename: str, sheet_name: str) -> pd.ExcelWriter:
     writer_mode = _get_writer_mode(xlsx_filename)
-    logger.info("< Saving '%s' @ '%s'", sheet_name, xlsx_filename)
+    logger.debug("< Saving '%s' @ '%s'", sheet_name, xlsx_filename)
     if writer_mode == "a":
         writer = pd.ExcelWriter(
             xlsx_filename, engine="openpyxl", mode=writer_mode, if_sheet_exists="replace"

--- a/ranking_table_tennis/helpers/gspread.py
+++ b/ranking_table_tennis/helpers/gspread.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List
 
 import gspread
@@ -5,6 +6,8 @@ import pandas as pd
 from gspread_dataframe import set_with_dataframe
 
 from ranking_table_tennis.configs import ConfigManager
+
+logger = logging.getLogger(__name__)
 
 
 def upload_sheet_from_df(
@@ -25,7 +28,7 @@ def upload_sheet_from_df(
     :param headers: This list will replace df column names and must have the same length.
     If headers are given, include_df_headers is turn to True.
     """
-    print("<<<Saving", sheet_name, "in", spreadsheet_id, sep="\t")
+    logger.info("< Saving '%s' @ '%s'", sheet_name, spreadsheet_id)
     try:
         worksheet = _get_ws_from_spreadsheet(sheet_name, spreadsheet_id)
 
@@ -44,7 +47,7 @@ def upload_sheet_from_df(
         )
 
     except ConnectionError:
-        print("<<<FAILED to upload", sheet_name, "in", spreadsheet_id, sep="\t")
+        logger.warn("!! FAILED to upload '%s' @ '%s'", sheet_name, spreadsheet_id)
 
 
 def load_and_upload_sheet(filename: str, sheet_name: str, spreadsheet_id: str) -> None:
@@ -82,12 +85,14 @@ def create_n_tour_sheet(spreadsheet_id: str, tid: str) -> None:
             dup_ws = wb.duplicate_sheet(ws.id, new_sheet_name=new_sheetname)
             dup_cell_value = dup_ws.acell("A1", value_render_option="FORMULA").value
             dup_ws.update_acell("A1", dup_cell_value.replace(first_key, replacement_key))
-            print("<<<Creating", new_sheetname, "from", sheetname, "in", spreadsheet_id, sep="\t")
+            logger.info(
+                "> Creating '%s' @ '%s' from '%s'", new_sheetname, spreadsheet_id, sheetname
+            )
         else:
-            print("FAILED TO DUPLICATE", first_key, "do not exist in", spreadsheet_id, sep="\t")
+            logger.warn("!! FAIL TO DUPLICATE '%s' do not exist @ '%s'", first_key, spreadsheet_id)
 
     except ConnectionError:
-        print("<<<Connection Error. FAILED TO DUPLICATE", first_key, "in", spreadsheet_id, sep="\t")
+        logger.warn("!! Connection Error. FAIL TO DUPLICATE '%s' @ '%s'", first_key, spreadsheet_id)
 
 
 def publish_to_web(tid: str, show_on_web=False) -> None:
@@ -121,10 +126,10 @@ def _get_gc() -> gspread.Client:
         else:
             gc = gspread.oauth()
     except FileNotFoundError:
-        print("The .json key file has not been configured. Upload will fail.")
+        logger.warn("!! The .json key file has not been configured. Upload will fail.")
         raise ConnectionError
     # except OSError:
-    #     print("Connection failure. Upload will fail.")
+    #     logger.warn("!!Connection failure. Upload will fail.")
 
     return gc
 

--- a/ranking_table_tennis/helpers/initial_rating.py
+++ b/ranking_table_tennis/helpers/initial_rating.py
@@ -1,7 +1,11 @@
+import logging
+
 import pandas as pd
 
 from ranking_table_tennis import helpers, models
 from ranking_table_tennis.configs import ConfigManager
+
+logger = logging.getLogger(__name__)
 
 
 def print_rating_context(
@@ -11,8 +15,8 @@ def print_rating_context(
     tid: str,
 ) -> None:
     # Helper to assign an initial rating to name
-    print("> Information that should help you assign rating")
-    print("\n> Matches")
+    print("# Information that should help you assign rating")
+    print("\n# Matches")
 
     cfg = ConfigManager().current_config
 
@@ -30,11 +34,11 @@ def print_rating_context(
             .dropna()
             .unique()
         )
-        print("\n> Known ratings")
+        print("\n# Known ratings")
         for pid in pids_selected:
             print(
-                f"> {tids[-2]}, {players[pid]['name']}, "
+                f"# {tids[-2]}, {players[pid]['name']}, "
                 f"rating: {known_rankings.get_entries(tids[-2], pid).get('rating')}"
             )
     except FileNotFoundError:
-        print("> Sorry, not available data to help you\n")
+        logger.warn("Sorry, previous rankings not available to help you")

--- a/ranking_table_tennis/helpers/logging.py
+++ b/ranking_table_tennis/helpers/logging.py
@@ -1,0 +1,13 @@
+import logging
+import logging.config
+import os
+
+import yaml
+
+root = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+
+with open(os.path.join(root, "config/logging.yaml"), "r") as f:
+    config = yaml.safe_load(f.read())
+    logging.config.dictConfig(config)
+
+logger = logging.getLogger("ranking_table_tennis")

--- a/ranking_table_tennis/helpers/markdown.py
+++ b/ranking_table_tennis/helpers/markdown.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import matplotlib.pyplot as plt
@@ -5,13 +6,15 @@ import pandas as pd
 
 from ranking_table_tennis.configs import ConfigManager
 
+logger = logging.getLogger(__name__)
+
 
 def publish_sheet_as_markdown(df, headers, sheet_name, tid, index=False):
     cfg = ConfigManager().current_config
     # Create folder to publish markdowns
     os.makedirs(f"{cfg.io.data_folder}{tid}", exist_ok=True)
     markdown_filename = f"{cfg.io.data_folder}{tid}/{sheet_name.replace(' ', '_')}.md"
-    print("<<<Saving", sheet_name, "in", markdown_filename, sep="\t")
+    logger.info("<<<Saving\t%s\tin\t%s", sheet_name, markdown_filename)
     df.to_markdown(
         markdown_filename, index=index, headers=headers, stralign="center", numalign="center"
     )

--- a/ranking_table_tennis/helpers/markdown.py
+++ b/ranking_table_tennis/helpers/markdown.py
@@ -14,7 +14,7 @@ def publish_sheet_as_markdown(df, headers, sheet_name, tid, index=False):
     # Create folder to publish markdowns
     os.makedirs(f"{cfg.io.data_folder}{tid}", exist_ok=True)
     markdown_filename = f"{cfg.io.data_folder}{tid}/{sheet_name.replace(' ', '_')}.md"
-    logger.info("<<<Saving\t%s\tin\t%s", sheet_name, markdown_filename)
+    logger.info("< Saving '%s' @ '%s'", sheet_name, markdown_filename)
     df.to_markdown(
         markdown_filename, index=index, headers=headers, stralign="center", numalign="center"
     )

--- a/ranking_table_tennis/helpers/pickle.py
+++ b/ranking_table_tennis/helpers/pickle.py
@@ -24,14 +24,14 @@ def save_to_pickle(
     objects_filenames = [(obj, fn) for obj, fn in zip(objects, filenames) if obj]
 
     for obj, fn in objects_filenames:
-        logger.info("< Saving '%s' @ '%s'", fn, cfg.io.data_folder)
+        logger.debug("< Saving '%s' @ '%s'", fn, cfg.io.data_folder)
         with open(os.path.join(cfg.io.data_folder, fn), "wb") as fo:
             pickle.dump(obj, fo, pickle.HIGHEST_PROTOCOL)
 
 
 def load_from_pickle(filename: str) -> Any:
     cfg = ConfigManager().current_config
-    logger.info("> Loading '%s' @ '%s'", filename, cfg.io.data_folder)
+    logger.debug("> Loading '%s' @ '%s'", filename, cfg.io.data_folder)
     with open(os.path.join(cfg.io.data_folder, filename), "rb") as fo:
         obj = pickle.load(fo)
 

--- a/ranking_table_tennis/helpers/pickle.py
+++ b/ranking_table_tennis/helpers/pickle.py
@@ -24,14 +24,14 @@ def save_to_pickle(
     objects_filenames = [(obj, fn) for obj, fn in zip(objects, filenames) if obj]
 
     for obj, fn in objects_filenames:
-        logger.info("<<<Saving\t%s\tin\t%s", fn, cfg.io.data_folder)
+        logger.info("< Saving '%s' @ '%s'", fn, cfg.io.data_folder)
         with open(os.path.join(cfg.io.data_folder, fn), "wb") as fo:
             pickle.dump(obj, fo, pickle.HIGHEST_PROTOCOL)
 
 
 def load_from_pickle(filename: str) -> Any:
     cfg = ConfigManager().current_config
-    logger.info(">>>Loading\t%s\tfrom\t%s", filename, cfg.io.data_folder)
+    logger.info("> Loading '%s' @ '%s'", filename, cfg.io.data_folder)
     with open(os.path.join(cfg.io.data_folder, filename), "rb") as fo:
         obj = pickle.load(fo)
 

--- a/ranking_table_tennis/helpers/pickle.py
+++ b/ranking_table_tennis/helpers/pickle.py
@@ -1,9 +1,12 @@
+import logging
 import os
 import pickle
 from typing import Any
 
 from ranking_table_tennis import models
 from ranking_table_tennis.configs import ConfigManager
+
+logger = logging.getLogger(__name__)
 
 
 def save_to_pickle(
@@ -21,14 +24,14 @@ def save_to_pickle(
     objects_filenames = [(obj, fn) for obj, fn in zip(objects, filenames) if obj]
 
     for obj, fn in objects_filenames:
-        print("<<<Saving", fn, "in", cfg.io.data_folder, sep="\t")
+        logger.info("<<<Saving\t%s\tin\t%s", fn, cfg.io.data_folder)
         with open(os.path.join(cfg.io.data_folder, fn), "wb") as fo:
             pickle.dump(obj, fo, pickle.HIGHEST_PROTOCOL)
 
 
 def load_from_pickle(filename: str) -> Any:
     cfg = ConfigManager().current_config
-    print(">>>Loading", filename, "from", cfg.io.data_folder, sep="\t")
+    logger.info(">>>Loading\t%s\tfrom\t%s", filename, cfg.io.data_folder)
     with open(os.path.join(cfg.io.data_folder, filename), "rb") as fo:
         obj = pickle.load(fo)
 

--- a/ranking_table_tennis/helpers/temp_players.py
+++ b/ranking_table_tennis/helpers/temp_players.py
@@ -38,8 +38,8 @@ def save_temp_players_ranking(players_temp: models.Players, ranking_temp: models
     # Loading temp ranking and players. It shuould be deleted after a successful preprocessing
     players_temp_file = os.path.join(cfg.io.data_folder, cfg.io.pickle.players_temp)
     ranking_temp_file = os.path.join(cfg.io.data_folder, cfg.io.pickle.ranking_temp)
-    logger.info(
-        "<Saving\t\tTemps to resume preprocessing (if necessary) %s %s",
+    logger.debug(
+        "< Saving temp resume files: '%s' '%s'",
         ranking_temp_file,
         players_temp_file,
     )
@@ -53,7 +53,7 @@ def remove_temp_players_ranking() -> None:
     cfg = ConfigManager().current_config
     players_temp_file = os.path.join(cfg.io.data_folder, cfg.io.pickle.players_temp)
     ranking_temp_file = os.path.join(cfg.io.data_folder, cfg.io.pickle.ranking_temp)
-    logger.info(">< Removing temp resume files %s %s", players_temp_file, ranking_temp_file)
+    logger.debug(">< Removing temp resume files '%s' '%s'", players_temp_file, ranking_temp_file)
     if os.path.exists(players_temp_file):
         os.remove(players_temp_file)
     if os.path.exists(ranking_temp_file):

--- a/ranking_table_tennis/helpers/temp_players.py
+++ b/ranking_table_tennis/helpers/temp_players.py
@@ -53,11 +53,7 @@ def remove_temp_players_ranking() -> None:
     cfg = ConfigManager().current_config
     players_temp_file = os.path.join(cfg.io.data_folder, cfg.io.pickle.players_temp)
     ranking_temp_file = os.path.join(cfg.io.data_folder, cfg.io.pickle.ranking_temp)
-    logger.info(
-        "Removing temp files created to resume preprocessing %s %s",
-        players_temp_file,
-        ranking_temp_file,
-    )
+    logger.info(">< Removing temp resume files %s %s", players_temp_file, ranking_temp_file)
     if os.path.exists(players_temp_file):
         os.remove(players_temp_file)
     if os.path.exists(ranking_temp_file):

--- a/ranking_table_tennis/helpers/temp_players.py
+++ b/ranking_table_tennis/helpers/temp_players.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pickle
 from typing import Tuple
@@ -5,6 +6,8 @@ from typing import Tuple
 from ranking_table_tennis import models
 from ranking_table_tennis.configs import ConfigManager
 from ranking_table_tennis.helpers.pickle import load_from_pickle
+
+logger = logging.getLogger(__name__)
 
 
 def load_temp_players_ranking() -> Tuple[models.Players, models.Rankings]:
@@ -16,13 +19,13 @@ def load_temp_players_ranking() -> Tuple[models.Players, models.Rankings]:
 
     if os.path.exists(players_temp_file):
         players_temp = load_from_pickle(cfg.io.pickle.players_temp)
-        print("Resume preprocessing...")
+        logger.info("Resume preprocessing...")
     else:
         players_temp = models.Players()
 
     if os.path.exists(ranking_temp_file):
         ranking_temp = load_from_pickle(cfg.io.pickle.ranking_temp)
-        print("Resume preprocessing...")
+        logger.info("Resume preprocessing...")
     else:
         ranking_temp = models.Rankings()
 
@@ -35,11 +38,10 @@ def save_temp_players_ranking(players_temp: models.Players, ranking_temp: models
     # Loading temp ranking and players. It shuould be deleted after a successful preprocessing
     players_temp_file = os.path.join(cfg.io.data_folder, cfg.io.pickle.players_temp)
     ranking_temp_file = os.path.join(cfg.io.data_folder, cfg.io.pickle.ranking_temp)
-    print(
-        "<Saving\t\tTemps to resume preprocessing (if necessary)",
+    logger.info(
+        "<Saving\t\tTemps to resume preprocessing (if necessary) %s %s",
         ranking_temp_file,
         players_temp_file,
-        "\n",
     )
     with open(players_temp_file, "wb") as ptf, open(ranking_temp_file, "wb") as rtf:
         # Pickle the 'data' dictionary using the highest protocol available.
@@ -51,8 +53,10 @@ def remove_temp_players_ranking() -> None:
     cfg = ConfigManager().current_config
     players_temp_file = os.path.join(cfg.io.data_folder, cfg.io.pickle.players_temp)
     ranking_temp_file = os.path.join(cfg.io.data_folder, cfg.io.pickle.ranking_temp)
-    print(
-        "Removing temp files created to resume preprocessing", players_temp_file, ranking_temp_file
+    logger.info(
+        "Removing temp files created to resume preprocessing %s %s",
+        players_temp_file,
+        ranking_temp_file,
     )
     if os.path.exists(players_temp_file):
         os.remove(players_temp_file)

--- a/ranking_table_tennis/models/players.py
+++ b/ranking_table_tennis/models/players.py
@@ -1,7 +1,10 @@
+import logging
 from typing import List
 
 import pandas as pd
 from unidecode import unidecode
+
+logger = logging.getLogger(__name__)
 
 
 class Players:
@@ -29,8 +32,7 @@ class Players:
     def verify_and_normalize(self) -> None:
         duplicated = self.players_df.index.duplicated(keep=False)
         if duplicated.any():
-            print("Players entries duplicated")
-            print(self.players_df[duplicated])
+            logger.error("Players entries duplicated:\n%s", self.players_df[duplicated])
 
         self.players_df.fillna("", inplace=True)
 
@@ -47,7 +49,7 @@ class Players:
         uname = unidecode(name).title()
         pid = self.players_df[self.players_df.name == uname].first_valid_index()
         if pid is None:
-            print("WARNING: Unknown player:", uname)
+            logger.warn("WARNING: Unknown player: %s", uname)
 
         return pid
 

--- a/ranking_table_tennis/models/tournaments.py
+++ b/ranking_table_tennis/models/tournaments.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Iterator, List
 
 import pandas as pd
@@ -6,6 +7,8 @@ from unidecode import unidecode
 
 from ranking_table_tennis.configs import ConfigManager
 from ranking_table_tennis.models import Players
+
+logger = logging.getLogger(__name__)
 
 
 class Tournaments:
@@ -84,7 +87,7 @@ class Tournaments:
             match_row["winner"] = match_row["player_b"]
             match_row["loser"] = match_row["player_a"]
         else:
-            print("Failed to process matches, a tie was found at:\n", match_row)
+            logger.error("Failed to process matches, a tie was found at:\n%s", match_row)
             raise ImportError
 
         # changing labels of finals round match

--- a/ranking_table_tennis/preprocess.py
+++ b/ranking_table_tennis/preprocess.py
@@ -20,7 +20,7 @@ def main(offline=True):
 
     If offline=True it will execute preprocessing locally (not retrieving or uploading updates).
     """
-    logger.info("Starting preprocess")
+    logger.info("Starting preprocess!")
 
     ConfigManager().set_current_config(date="220101")
     cfg = ConfigManager().current_config
@@ -32,7 +32,7 @@ def main(offline=True):
             "\nDo you want to retrieve online sheet [Y/n]? (press Enter to continue)\n"
         )
         if retrieve.lower() != "n":
-            logger.info("Downloading and saving %s\n" % xlsx_file)
+            logger.info("Downloading and saving '%s'" % xlsx_file)
             request.urlretrieve(cfg.io.tournaments_gdrive, xlsx_file)
 
     # Loading all tournament data
@@ -52,7 +52,7 @@ def main(offline=True):
     players_temp, ranking_temp = helpers.load_temp_players_ranking()
 
     for tid in tournaments:
-        logger.info("== %s ==", tid)
+        logger.info("** Processing %s", tid)
 
         for name in tournaments.get_players_names(tid):
             unknown_player = False
@@ -66,7 +66,7 @@ def main(offline=True):
                     # Save a temp player to resume preprocessing, if necessary
                     players_temp.add_player(players[players.get_pid(name)])
                 else:
-                    logger.info(">>>>\tUNCOMPLETE preprocessing detected. Resuming...")
+                    logger.info("~~ UNCOMPLETE preprocessing detected. Resuming...")
                     players.add_player(players_temp[players_temp.get_pid(name)])
                 logger.info(f"\n{players[players.get_pid(name)]}\n")
 

--- a/ranking_table_tennis/preprocess.py
+++ b/ranking_table_tennis/preprocess.py
@@ -28,9 +28,7 @@ def main(offline=True):
     xlsx_file = cfg.io.data_folder + cfg.io.xlsx.tournaments_filename
 
     if not offline:
-        retrieve = input(
-            "\nDo you want to retrieve online sheet [Y/n]? (press Enter to continue)\n"
-        )
+        retrieve = input("\nDo you want to retrieve online sheet [Y/n]? ")
         if retrieve.lower() != "n":
             logger.info("Downloading and saving '%s'" % xlsx_file)
             request.urlretrieve(cfg.io.tournaments_gdrive, xlsx_file)
@@ -87,7 +85,7 @@ def main(offline=True):
                     # Save a temp ranking of the player to resume preprocessing, if necessary
                     ranking_temp.add_entry(rankings[initial_tid, pid])
                 else:
-                    logger.info(">>>>\tUNCOMPLETE preprocessing detected. Resuming...")
+                    logger.info("~~ UNCOMPLETE preprocessing detected. Resuming...")
                     rankings.add_entry(ranking_temp[initial_tid, pid])
 
                 logger.info(
@@ -109,7 +107,7 @@ def main(offline=True):
     # Update the online version
     upload = False
     if not offline:
-        answer = input("\nDo you want to update online sheets [Y/n]? (press Enter to continue)\n")
+        answer = input("\nDo you want to update online sheets [Y/n]? ")
         upload = answer.lower() != "n"
 
     # Saving complete list of players, including new ones

--- a/ranking_table_tennis/preprocess.py
+++ b/ranking_table_tennis/preprocess.py
@@ -1,3 +1,4 @@
+import logging
 from urllib import request
 
 from ranking_table_tennis import helpers
@@ -17,7 +18,7 @@ def main(offline=True):
 
     If offline=True it will execute preprocessing locally (not retrieving or uploading updates).
     """
-    print("\n## Starting preprocess\n")
+    logging.info("\n## Starting preprocess\n")
 
     ConfigManager().set_current_config(date="220101")
     cfg = ConfigManager().current_config
@@ -27,7 +28,7 @@ def main(offline=True):
     if not offline:
         retrieve = input("Do you want to retrieve online sheet [Y/n]? (press Enter to continue)\n")
         if retrieve.lower() != "n":
-            print("Downloading and saving %s\n" % xlsx_file)
+            logging.info("Downloading and saving %s\n" % xlsx_file)
             request.urlretrieve(cfg.io.tournaments_gdrive, xlsx_file)
 
     # Loading all tournament data
@@ -47,7 +48,7 @@ def main(offline=True):
     players_temp, ranking_temp = helpers.load_temp_players_ranking()
 
     for tid in tournaments:
-        print("==", tid, "==")
+        logging.info("== %s ==", tid)
 
         for name in tournaments.get_players_names(tid):
             unknown_player = False
@@ -61,9 +62,9 @@ def main(offline=True):
                     # Save a temp player to resume preprocessing, if necessary
                     players_temp.add_player(players[players.get_pid(name)])
                 else:
-                    print(">>>>\tUNCOMPLETE preprocessing detected. Resuming...")
+                    logging.info(">>>>\tUNCOMPLETE preprocessing detected. Resuming...")
                     players.add_player(players_temp[players_temp.get_pid(name)])
-                print(f"\n{players[players.get_pid(name)]}\n")
+                logging.info(f"\n{players[players.get_pid(name)]}\n")
 
             pid = players.get_pid(name)
 
@@ -82,10 +83,10 @@ def main(offline=True):
                     # Save a temp ranking of the player to resume preprocessing, if necessary
                     ranking_temp.add_entry(rankings[initial_tid, pid])
                 else:
-                    print(">>>>\tUNCOMPLETE preprocessing detected. Resuming...")
+                    logging.info(">>>>\tUNCOMPLETE preprocessing detected. Resuming...")
                     rankings.add_entry(ranking_temp[initial_tid, pid])
 
-                print(
+                logging.info(
                     f"\n{rankings[initial_tid, pid][['tid', 'pid', 'rating', 'category']]}\n"
                     f"{players[pid]['name']}"
                 )

--- a/ranking_table_tennis/publish.py
+++ b/ranking_table_tennis/publish.py
@@ -1,5 +1,9 @@
+import logging
+
 from ranking_table_tennis import helpers
 from ranking_table_tennis.configs import ConfigManager
+
+logger = logging.getLogger(__name__)
 
 
 def main(offline=True, last=True, tournament_num=None):
@@ -15,7 +19,7 @@ def main(offline=True, last=True, tournament_num=None):
 
     tournament_num (int): enter the number of a valid tournament. if given, last is ommited
     """
-    print("\n## Starting publish\n")
+    logger.info("## Starting publish")
 
     ConfigManager().set_current_config(date="220101")
     cfg = ConfigManager().current_config
@@ -55,6 +59,10 @@ def main(offline=True, last=True, tournament_num=None):
             "\nDo you want to publish to backend online sheets [Y/n]? (press Enter to continue)\n"
         )
         upload = answer.lower() != "n"
+
+    # Update config
+    tournament_date = tournaments[tid].iloc[0].date.strftime("%y%m%d")
+    ConfigManager().set_current_config(date=tournament_date)
 
     # Publish formated rating of selected tournament
     helpers.publish_rating_sheet(tournaments, rankings, players, tid, prev_tid, upload=upload)

--- a/ranking_table_tennis/publish.py
+++ b/ranking_table_tennis/publish.py
@@ -44,7 +44,7 @@ def main(offline=True, last=True, tournament_num=None):
         for tenum, tid in enumerate(tids[1:], 1):
             print(f"{tenum:d}\t->\t{tid}")
 
-        t_num = int(input("Enter the tournament number to publish (look above):\n"))
+        t_num = int(input("Enter the tournament number to publish: "))
         tid = tids[t_num]
     # An explicit tournament num will overwrite other options
     if tournament_num:
@@ -55,9 +55,7 @@ def main(offline=True, last=True, tournament_num=None):
 
     upload = False
     if not offline:
-        answer = input(
-            "\nDo you want to publish to backend online sheets [Y/n]? (press Enter to continue)\n"
-        )
+        answer = input("\nDo you want to publish to backend online sheets [Y/n]? ")
         upload = answer.lower() != "n"
 
     # Update config
@@ -95,7 +93,7 @@ def main(offline=True, last=True, tournament_num=None):
     helpers.publish_statistics_sheet(tournaments, rankings, players, tid, prev_tid, upload=upload)
 
     if not offline:
-        answer = input("\nDo you want to publish to the web [Y/n]? (press Enter to continue)\n")
+        answer = input("\nDo you want to publish to the web [Y/n]? ")
         show_on_web = (answer.lower() != "n") and (tid != tids[1])
 
         helpers.publish_to_web(tid, show_on_web)

--- a/ranking_table_tennis/publish.py
+++ b/ranking_table_tennis/publish.py
@@ -19,7 +19,7 @@ def main(offline=True, last=True, tournament_num=None):
 
     tournament_num (int): enter the number of a valid tournament. if given, last is ommited
     """
-    logger.info("## Starting publish")
+    logger.info("Starting publish!")
 
     ConfigManager().set_current_config(date="220101")
     cfg = ConfigManager().current_config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,13 @@
 import glob
+import logging
 import os
 import shutil
 
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
+
+logger = logging.getLogger(__name__)
 
 
 def pytest_sessionstart(session):
@@ -14,9 +17,9 @@ def pytest_sessionstart(session):
     """
     data_rtt_folder = os.path.join(os.path.dirname(__file__), "data_rtt")
 
-    print("\n## Before starting tests\n")
+    logger.debug("## Before starting tests...")
     if os.path.exists(data_rtt_folder):
-        print(f"\nRemoving data folder before tests: remove {data_rtt_folder}")
+        logger.debug("Removing data folder before tests: remove %", data_rtt_folder)
         shutil.rmtree(data_rtt_folder)
 
 
@@ -27,9 +30,9 @@ def pytest_sessionfinish(session, exitstatus):
     """
     data_rtt_folder = os.path.join(os.path.dirname(__file__), "data_rtt")
 
-    print("\n## After tests have finalized\n")
+    logger.debug("## After tests have finalized...")
     if os.path.exists(data_rtt_folder):
-        print(f"\nRemoving data folder after test: remove {data_rtt_folder}")
+        logger.debug("Removing data folder after test: remove %s", data_rtt_folder)
         shutil.rmtree(data_rtt_folder)
 
 
@@ -45,7 +48,7 @@ def assert_equals_xlsx(reference_folder, output_folder, name_pattern):
         assert sorted(dfs_expected.keys()) == sorted(dfs_output.keys()), "Sheetname differences"
 
         for name, df in dfs_expected.items():
-            print(fn, name)
+            logger.info("Verifying: %s : %s", fn, name)
             assert_frame_equal(df, dfs_output[name])
 
 


### PR DESCRIPTION
Start using logging instead of prints for showing information during runtime. Also enables to classify some messages as debugging, warnings, or errors.

A big improvement have been done. Minor tweaks could be down the way for later.

Resolves #28 