### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/ranking_table_tennis/helpers/gspread.py
+++ b/ranking_table_tennis/helpers/gspread.py
@@ -74,7 +74,7 @@ def _get_gc() -> gspread.Client:
         github_secret_name = "GCP_SA_KEY"
         credentials_str = os.getenv(github_secret_name)
         if credentials_str:
-            logger.debug("Loading GCP SA credentials from %s", github_secret_name)
+            logger.debug("Loading GCP SA credentials from configured environment variable")
             credentials_dict = json.loads(credentials_str)
             gc = gspread.service_account_from_dict(credentials_dict)
         else:


### PR DESCRIPTION
Potential fix for [https://github.com/srvanrell/ranking-table-tennis/security/code-scanning/2](https://github.com/srvanrell/ranking-table-tennis/security/code-scanning/2)

General fix: remove or redact sensitive identifiers from log messages, especially anything related to secrets, credentials, tokens, or secret-store keys.

Best fix here (without changing behavior): in `ranking_table_tennis/helpers/gspread.py`, replace the debug message on line 77 so it no longer interpolates `github_secret_name`. Keep the operational meaning of the log while avoiding secret metadata disclosure. No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
