### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/srvanrell/ranking-table-tennis/security/code-scanning/1](https://github.com/srvanrell/ranking-table-tennis/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained regardless of repository/org defaults.  
Best fix here: set workflow-level permissions to the minimum required by this pipeline:

- `contents: read`

This preserves existing functionality (checkout and test execution) while removing implicit broader token scope.  
Change location: `.github/workflows/regression_tests.yml`, at the workflow root (after `on:` block and before `jobs:`).

No imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
